### PR TITLE
Adding documentation to types and functions.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -18,24 +18,29 @@ import (
 	"strings"
 )
 
+// InputValues is an array of input files
 type InputValues []string
 
+// String is part of an implementation of the flag.Value interface
 func (v *InputValues) String() string {
 	return ""
 }
 
+// Set is part of an implementation of the flag.Value interface
 func (v *InputValues) Set(value string) error {
 	*v = append(*v, value)
 	return nil
 }
 
-type CLIOptions struct {
+// Options is an arguments container for running the CLI.
+type Options struct {
 	InputHCL      InputValues
 	BuildPath     string
 	ResourcesPath string
 }
 
-func StartCLI(opts *CLIOptions) {
+// Start runs the command line utility logic.
+func Start(opts *Options) {
 	var errors error
 	l := log.New(os.Stderr, "", 0)
 

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kevinswiber/apigee-hcl/config/policy"
 )
 
+// Config is a container for holding the contents of an exported Apigee proxy bundle
 type Config struct {
 	Proxy           *Proxy
 	ProxyEndpoints  []*ProxyEndpoint
@@ -16,6 +17,7 @@ type Config struct {
 	Resources       map[string]string
 }
 
+// LoadConfigFromHCL converts an HCL ast.ObjectList into a Config object
 func LoadConfigFromHCL(list *ast.ObjectList) (*Config, error) {
 	var errors *multierror.Error
 

--- a/config/flow.go
+++ b/config/flow.go
@@ -7,12 +7,20 @@ import (
 	"github.com/hashicorp/hcl/hcl/ast"
 )
 
+// PreFlow represents a <PreFlow/> element for
+// ProxyEndpoint and TargetEndpoint definitions.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#flows
 type PreFlow struct {
 	XMLName  string       `xml:"PreFlow" hcl:"-"`
 	Request  FlowRequest  `hcl:"request"`
 	Response FlowResponse `hcl:"response"`
 }
 
+// Flow represents a <Flow/> element for
+// ProxyEndpoint and TargetEndpoint definitions.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#flows
 type Flow struct {
 	XMLName   string       `xml:"Flow" hcl:"-"`
 	Name      string       `xml:"name,attr" hcl:"-"`
@@ -21,18 +29,30 @@ type Flow struct {
 	Response  FlowResponse `hcl:"response"`
 }
 
+// PostFlow represents a <PostFlow/> element for
+// ProxyEndpoint and TargetEndpoint definitions.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#flows
 type PostFlow struct {
 	XMLName  string       `xml:"PostFlow" hcl:"-"`
 	Request  FlowRequest  `hcl:"request"`
 	Response FlowResponse `hcl:"response"`
 }
 
+// PostClientFlow represents a <PostClientFlow/> element for
+// ProxyEndpoint definitions.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#flows
 type PostClientFlow struct {
 	XMLName  string       `xml:"PostClientFlow" hcl:"-"`
 	Request  FlowRequest  `hcl:"request"`
 	Response FlowResponse `hcl:"response"`
 }
 
+// FaultRule represents a <FaultRule/> element for
+// ProxyEndpoint and TargetEndpoint definitions.
+//
+// Documentation: http://docs.apigee.com/api-services/content/fault-handling
 type FaultRule struct {
 	XMLName   string      `xml:"FaultRule" hcl:"-"`
 	Name      string      `xml:"name,attr" hcl:"-"`
@@ -40,6 +60,10 @@ type FaultRule struct {
 	Steps     []*FlowStep `xml:",innerxml" hcl:"step"`
 }
 
+// DefaultFaultRule represents a <DefaultFaultRule/> element for
+// ProxyEndpoint and TargetEndpoint definitions.
+//
+// Documentation: http://docs.apigee.com/api-services/content/fault-handling
 type DefaultFaultRule struct {
 	XMLName       string      `xml:"DefaultFaultRule" hcl:"-"`
 	Name          string      `xml:"name,attr" hcl:"-"`
@@ -48,17 +72,30 @@ type DefaultFaultRule struct {
 	AlwaysEnforce bool        `xml:",omitempty" hcl:"always_enforce"`
 }
 
+// FlowStep represents a <Step/> element for
+// Request and Response flows in ProxyEndpoint and
+// TargetEndpoint definitions.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#policies-policyattachment
 type FlowStep struct {
 	XMLName   string `xml:"Step"`
 	Name      string
 	Condition string `xml:",omitempty" hcl:"condition"`
 }
 
+// FlowRequest represents a <Request/> element for
+// PreFlow, Flow, PostFlow, and PostClientFlow definitions
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#watchaquickhowtovideo-flowconfigurationelements
 type FlowRequest struct {
 	XMLName string      `xml:"Request" hcl:"-"`
 	Steps   []*FlowStep `xml:",innerxml" hcl:"step"`
 }
 
+// FlowResponse represents a <Response/> element for
+// PreFlow, Flow, PostFlow, and PostClientFlow definitions
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#watchaquickhowtovideo-flowconfigurationelements
 type FlowResponse struct {
 	XMLName string      `xml:"Response" hcl:"-"`
 	Steps   []*FlowStep `xml:",innerxml" hcl:"step"`

--- a/config/policy/assign_message.go
+++ b/config/policy/assign_message.go
@@ -7,6 +7,9 @@ import (
 	"github.com/hashicorp/hcl/hcl/ast"
 )
 
+// AssignMessagePolicy represents an <AssignMessage/> element.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/assign-message-policy
 type AssignMessagePolicy struct {
 	XMLName                   string `xml:"AssignMessage" hcl:"-"`
 	Policy                    `hcl:",squash"`
@@ -101,6 +104,7 @@ type assignTo struct {
 	Value     string `xml:",chardata" hcl:"value"`
 }
 
+// LoadAssignMessageHCL converts an HCL ast.ObjectItem into an AssignMessagePolicy object.
 func LoadAssignMessageHCL(item *ast.ObjectItem) (interface{}, error) {
 	var errors *multierror.Error
 	var p AssignMessagePolicy

--- a/config/policy/extract_variables.go
+++ b/config/policy/extract_variables.go
@@ -8,6 +8,9 @@ import (
 	"github.com/kevinswiber/apigee-hcl/config/hclerror"
 )
 
+// ExtractVariablesPolicy represents an <ExtractVariables/> element.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/extract-variables-policy
 type ExtractVariablesPolicy struct {
 	XMLName                   string `xml:"ExtractVariables" hcl:"-"`
 	Policy                    `hcl:",squash"`
@@ -96,6 +99,7 @@ type evPattern struct {
 	Value      string `xml:",chardata" hcl:"value"`
 }
 
+// LoadExtractVariablesHCL converts an HCL ast.ObjectItem into an ExtractVariablesPolicy object.
 func LoadExtractVariablesHCL(item *ast.ObjectItem) (interface{}, error) {
 	var errors *multierror.Error
 	var p ExtractVariablesPolicy

--- a/config/policy/javascript.go
+++ b/config/policy/javascript.go
@@ -7,6 +7,9 @@ import (
 	"github.com/kevinswiber/apigee-hcl/config/common"
 )
 
+// JavaScriptPolicy represents a <Javascript/> element.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/javascript-policy
 type JavaScriptPolicy struct {
 	XMLName     string `xml:"Javascript" hcl:"-"`
 	Policy      `hcl:",squash"`
@@ -18,6 +21,7 @@ type JavaScriptPolicy struct {
 	Content     string             `xml:"-" hcl:"content"`
 }
 
+// LoadJavaScriptHCL converts HCL into an JavaScriptPolicy object.
 func LoadJavaScriptHCL(item *ast.ObjectItem) (interface{}, error) {
 	var p JavaScriptPolicy
 

--- a/config/policy/policy.go
+++ b/config/policy/policy.go
@@ -6,6 +6,9 @@ import (
 	"github.com/hashicorp/hcl/hcl/ast"
 )
 
+// Policy Represents a base Policy element. Each policy type should embed a Policy.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#policies
 type Policy struct {
 	Name            string `xml:"name,attr,omitempty" hcl:"-"`
 	Enabled         bool   `xml:"enabled,attr" hcl:"enabled"`
@@ -13,6 +16,7 @@ type Policy struct {
 	Async           bool   `xml:"async,attr,omitempty" hcl:"async"`
 }
 
+// LoadCommonPolicyHCL converts an HCL ast.ObjectItem into a Policy object.
 func LoadCommonPolicyHCL(item *ast.ObjectItem, p *Policy) error {
 
 	if err := hcl.DecodeObject(p, item.Val.(*ast.ObjectType)); err != nil {

--- a/config/policy/quota.go
+++ b/config/policy/quota.go
@@ -7,6 +7,9 @@ import (
 	"github.com/hashicorp/hcl/hcl/ast"
 )
 
+// QuotaPolicy represents a <Quota/> element.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/quota-policy
 type QuotaPolicy struct {
 	XMLName                   string `xml:"Quota" hcl:"-"`
 	Policy                    `hcl:",squash"`
@@ -70,6 +73,7 @@ type messageWeight struct {
 	Ref     string `xml:"ref,attr,omitempty" hcl:"ref"`
 }
 
+// LoadQuotaHCL converts an HCL ast.ObjectItem into a QuotaPolicy object.
 func LoadQuotaHCL(item *ast.ObjectItem) (interface{}, error) {
 	var errors *multierror.Error
 	var p QuotaPolicy

--- a/config/policy/raise_fault.go
+++ b/config/policy/raise_fault.go
@@ -7,6 +7,9 @@ import (
 	"github.com/hashicorp/hcl/hcl/ast"
 )
 
+// RaiseFaultPolicy represents a <RaiseFaultPolicy/> element.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/raise-fault-policy
 type RaiseFaultPolicy struct {
 	XMLName                   string `xml:"RaiseFault" hcl:"-"`
 	Policy                    `hcl:",squash"`
@@ -42,6 +45,7 @@ type raiseFaultSet struct {
 	ReasonPhrase string    `xml:",omitempty" hcl:"reason_phrase"`
 }
 
+// LoadRaiseFaultHCL converts an HCL ast.ObjectItem into a RaiseFaultPolicy.
 func LoadRaiseFaultHCL(item *ast.ObjectItem) (interface{}, error) {
 	var p RaiseFaultPolicy
 

--- a/config/policy/response_cache.go
+++ b/config/policy/response_cache.go
@@ -5,6 +5,9 @@ import (
 	"github.com/hashicorp/hcl/hcl/ast"
 )
 
+// ResponseCachePolicy represents a <ResponseCache/> element.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/response-cache-policy
 type ResponseCachePolicy struct {
 	XMLName                     string `xml:"ResponseCache" hcl:"-"`
 	Policy                      `hcl:",squash"`
@@ -59,6 +62,7 @@ type expiryDate struct {
 	Value   string `xml:",chardata" hcl:"value"`
 }
 
+// LoadResponseCacheHCL converts an HCL ast.ObjectItem into a ResponseCachePolicy
 func LoadResponseCacheHCL(item *ast.ObjectItem) (interface{}, error) {
 	var p ResponseCachePolicy
 

--- a/config/policy/script.go
+++ b/config/policy/script.go
@@ -5,6 +5,9 @@ import (
 	"github.com/hashicorp/hcl/hcl/ast"
 )
 
+// ScriptPolicy represents a <Script/> element.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/python-script-policy
 type ScriptPolicy struct {
 	XMLName     string `xml:"Script" hcl:"-"`
 	Policy      `hcl:",squash"`
@@ -14,6 +17,7 @@ type ScriptPolicy struct {
 	Content     string   `xml:"-" hcl:"content"`
 }
 
+// LoadScriptHCL converts an HCL ast.ObjectItem into a ScriptPolicy object.
 func LoadScriptHCL(item *ast.ObjectItem) (interface{}, error) {
 	var p ScriptPolicy
 

--- a/config/policy/spike_arrest.go
+++ b/config/policy/spike_arrest.go
@@ -5,6 +5,9 @@ import (
 	"github.com/hashicorp/hcl/hcl/ast"
 )
 
+// SpikeArrestPolicy represents a <SpikeArrest/> element.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/spike-arrest-policy
 type SpikeArrestPolicy struct {
 	XMLName       string `xml:"SpikeArrest" hcl:"-"`
 	Policy        `hcl:",squash"`
@@ -30,6 +33,7 @@ type spikeRate struct {
 	Value   string `xml:",chardata" hcl:"value"`
 }
 
+// LoadSpikeArrestHCL converts an HCL ast.ObjectItem into a SpikeArrestPolicy object.
 func LoadSpikeArrestHCL(item *ast.ObjectItem) (interface{}, error) {
 	var p SpikeArrestPolicy
 

--- a/config/policy/verify_api_key.go
+++ b/config/policy/verify_api_key.go
@@ -5,6 +5,9 @@ import (
 	"github.com/hashicorp/hcl/hcl/ast"
 )
 
+// VerifyAPIKeyPolicy represents a <VerifyAPIKey/> element.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/verify-api-key-policy
 type VerifyAPIKeyPolicy struct {
 	XMLName     string `xml:"VerifyAPIKey" hcl:"-"`
 	Policy      `hcl:",squash"`
@@ -18,6 +21,7 @@ type apikey struct {
 	Value   string `xml:",chardata" hcl:"value"`
 }
 
+// LoadVerifyAPIKeyHCL converts an HCL ast.ObjectItem into a VerifyAPIKeyPolicy object.
 func LoadVerifyAPIKeyHCL(item *ast.ObjectItem) (interface{}, error) {
 	var p VerifyAPIKeyPolicy
 

--- a/config/policy_list.go
+++ b/config/policy_list.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kevinswiber/apigee-hcl/config/policy"
 )
 
+// PolicyList is a map of HCL policy types to HCL loader functions.
 var PolicyList = map[string]func(*ast.ObjectItem) (interface{}, error){
 	"assign_message":    policy.LoadAssignMessageHCL,
 	"extract_variables": policy.LoadExtractVariablesHCL,

--- a/config/proxy.go
+++ b/config/proxy.go
@@ -8,6 +8,9 @@ import (
 	"github.com/kevinswiber/apigee-hcl/config/hclerror"
 )
 
+// Proxy represents an <APIProxy/> element in an Apigee proxy bundle
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#baseconfig
 type Proxy struct {
 	XMLName     string `xml:"APIProxy", hcl:"-"`
 	Name        string `xml:"name,attr,omitempty" hcl:"-"`

--- a/config/proxy_endpoint.go
+++ b/config/proxy_endpoint.go
@@ -9,6 +9,9 @@ import (
 	"github.com/kevinswiber/apigee-hcl/config/hclerror"
 )
 
+// ProxyEndpoint represents a <ProxyEndpoint/> element.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#proxyendpoint
 type ProxyEndpoint struct {
 	XMLName             string               `xml:"ProxyEndpoint" hcl:"-"`
 	Name                string               `xml:"name,attr" hcl:"-"`
@@ -22,6 +25,10 @@ type ProxyEndpoint struct {
 	RouteRules          []*RouteRule         `xml:"RouteRule" hcl:"route_rule"`
 }
 
+// HTTPProxyConnection represents an <HTTPProxyConnection/> element
+// in a ProxyEndpoint.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#proxyendpoint-proxyendpointconfigurationelements
 type HTTPProxyConnection struct {
 	XMLName      string             `xml:"HTTPProxyConnection" hcl:"-"`
 	BasePath     string             `hcl:"base_path"`
@@ -29,6 +36,9 @@ type HTTPProxyConnection struct {
 	Properties   []*common.Property `xml:"Properties>Property" hcl:"properties"`
 }
 
+// RouteRule represents a <RouteRule/> element in an HTTPProxyConnection
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#proxyendpoint-proxyendpointconfigurationelements
 type RouteRule struct {
 	XMLName        string `xml:"RouteRule"`
 	Name           string `xml:"name,attr", hcl:"-"`

--- a/config/target_endpoint.go
+++ b/config/target_endpoint.go
@@ -9,6 +9,9 @@ import (
 	"github.com/kevinswiber/apigee-hcl/config/hclerror"
 )
 
+// TargetEndpoint represents a <TargetEndpoint/> element.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#targetendpoint
 type TargetEndpoint struct {
 	XMLName               string                 `xml:"TargetEndpoint" hcl:"-"`
 	Name                  string                 `xml:"name,attr" hcl:"-"`
@@ -23,6 +26,10 @@ type TargetEndpoint struct {
 	SSLInfo               *SSLInfo               `xml:",omitempty" hcl:"ssl_info"`
 }
 
+// HTTPTargetConnection represents an <HTTPTargetConnection/> element
+// in a TargetEndpoint.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#targetendpoint-targetendpointconfigurationelements
 type HTTPTargetConnection struct {
 	XMLName      string             `xml:"HTTPTargetConnection" hcl:"-"`
 	URL          string             `hcl:"url"`
@@ -30,6 +37,10 @@ type HTTPTargetConnection struct {
 	Properties   []*common.Property `xml:"Properties>Property" hcl:"properties"`
 }
 
+// LoadBalancer represents a <LoadBalancer/> element in an
+// HTTPTargetConnection.
+//
+// Documentation: http://docs.apigee.com/api-platform/content/load-balance-api-traffic-across-multiple-backend-servers#configuringatargetendpointtoloadbalanceacrossnamedtargetservers
 type LoadBalancer struct {
 	XMLName      string                `xml:"LoadBalancer" hcl:"-"`
 	Algorithm    string                `hcl:"algorithm"`
@@ -38,6 +49,10 @@ type LoadBalancer struct {
 	RetryEnabled bool                  `xml:",omitempty" hcl:"retry_enabled"`
 }
 
+// LocalTargetConnection represents a <LocalTargetConnection/> element
+// in a TargetEndpoint.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#targetendpoint-targetendpointconfigurationelements
 type LocalTargetConnection struct {
 	XMLName       string `xml:"LocalTargetConnection" hcl:"-"`
 	APIProxy      string `xml:",omitempty" hcl:"api_proxy"`
@@ -45,6 +60,9 @@ type LocalTargetConnection struct {
 	Path          string `xml:",omitempty" hcl:"path"`
 }
 
+// ScriptTarget represents a <ScriptTarget/> element in a TargetEndpoint.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#targetendpoint-targetendpointconfigurationelements
 type ScriptTarget struct {
 	XMLName              string                 `xml:"ScriptTarget" hcl:"-"`
 	ResourceURL          string                 `hcl:"resource_url"`
@@ -52,6 +70,9 @@ type ScriptTarget struct {
 	Arguments            []string               `xml:"Arguments>Argument" hcl:"arguments"`
 }
 
+// SSLInfo represents an <SSLInfo/> element in a TargetEndpoint.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#tlsssltargetendpointconfiguration-tlsssltargetendpointconfigurationelements
 type SSLInfo struct {
 	XMLName           string   `xml:"SSLInfo" hcl:"-"`
 	Enabled           bool     `xml:",omitempty" hcl:"enabled"`
@@ -63,12 +84,20 @@ type SSLInfo struct {
 	Protocols         []string `xml:"Protocols>Protocol" hcl:"protocols"`
 }
 
+// EnvironmentVariable represents an <EnvironmentVariable/> element
+// in a ScriptTarget.
+//
+// Documentation: http://docs.apigee.com/api-services/reference/api-proxy-configuration-reference#targetendpoint-targetendpointconfigurationelements
 type EnvironmentVariable struct {
 	XMLName string      `xml:"EnvironmentVariable" hcl:"-"`
 	Name    string      `xml:"name,attr" hcl:",key"`
 	Value   interface{} `xml:",chardata" hcl:"-"`
 }
 
+// LoadBalancerServer represents a <LoadBalancerServer/> element
+// in a LoadBalancer.
+//
+// Documentation: http://docs.apigee.com/api-platform/content/load-balance-api-traffic-across-multiple-backend-servers#configuringatargetendpointtoloadbalanceacrossnamedtargetservers
 type LoadBalancerServer struct {
 	XMLName    string `xml:"Server" hcl:"-"`
 	Name       string `xml:"name,attr" hcl:"-"`

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	var options cli.CLIOptions
+	var options cli.Options
 
 	flag.Var(&options.InputHCL, "i", "Required. An HCL file to translate")
 	flag.StringVar(&options.BuildPath, "o", path.Join(".", "build"), "Optional. A build path")
@@ -19,5 +19,5 @@ func main() {
 		return
 	}
 
-	cli.StartCLI(&options)
+	cli.Start(&options)
 }


### PR DESCRIPTION
This clears all `golint` warnings.
